### PR TITLE
Use Node APN v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.2",
   "description": "Apple Push Notifications from your Hapi applications using Node APN",
   "main": "src/index.js",
+  "engines": {
+    "node": ">=8.8.1"
+  },
   "scripts": {
     "test": "echo \"Warning: no test specified\""
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/iainreid820/hapi-apn#readme",
   "dependencies": {
-    "apn": "^2.2.0"
+    "node-apn-http2": "^1.2.0"
   },
   "greenkeeper": {
     "commitMessages": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,10 @@
 const { Provider, Notification } = require('apn')
 
 exports.register = function (server, options = {}, next) {
-  server.decorate('server', 'apn', {
-    get connection() {
-      return new Provider(options)
-    },
+  const connection = new Provider(options)
 
+  server.decorate('server', 'apn', {
+    connection,
     Notification,
     Provider
   })


### PR DESCRIPTION
Update library to use a package that uses the native HTTP2 implementation.